### PR TITLE
[connectqueue] small typo fix

### DIFF
--- a/shared/sh_queue.lua
+++ b/shared/sh_queue.lua
@@ -487,7 +487,7 @@ local function playerConnect(name, setKickReason, deferrals)
 
     if not ids then
         -- prevent joining
-        done(Config.Language.iderr)
+        done(Config.Language.idrr)
         CancelEvent()
         Queue:DebugPrint("Dropped " .. name .. ", couldn't retrieve any of their id's")
         return


### PR DESCRIPTION
**Describe Pull request**
according to line 50 in the `server/qv_queue_config.lua` there is no `iderr` but there is `idrr` so I assume that's what it should be here.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) no
- Does your code fit the style guidelines? [yes/no] yes
- Does your PR fit the contribution guidelines? [yes/no] yes
